### PR TITLE
 🍼 Update formula and bottles for 1.4.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.rb]
+indent_size = 2

--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -2,27 +2,28 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      :tag => "v1.4.3",
-      :revision => "11a0e3e14e5a83aaaba193dfb6d18aa49a82b881"
+      :tag => "v1.4.4",
+      :revision => "3660365dd334cd852dd83d42ee016e267821a5de"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
     root_url "https://dl.bintray.com/phatblat/mas-bottles"
-    cellar :any_skip_relocation
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :mojave
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :high_sierra
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :sierra
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :el_capitan
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :yosemite
-    sha256 "84a34f9e4458b7bed57e013cc85ecb1df5fa165d458fed3a9e8c4a9ac43baada" => :mavericks
+    cellar :any
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :mojave
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :high_sierra
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :sierra
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :el_capitan
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :yosemite
+    sha256 "237fd7270cb8f0d68a33e7ce05671a2e5c269d05d736abb0f66b50215439084e" => :mavericks
   end
 
   depends_on "carthage" => :build
-  depends_on :xcode => ["10.0", :build]
+  depends_on :xcode => ["10.1", :build]
 
   def install
-    # Prevent warnings from causing build failures
-    # Prevent linker errors by telling all lib builds to use max size install names
+    # Working around build issues in dependencies
+    # - Prevent warnings from causing build failures
+    # - Prevent linker errors by telling all lib builds to use max size install names
     xcconfig = buildpath/"Overrides.xcconfig"
     xcconfig.write <<~EOS
       GCC_TREAT_WARNINGS_AS_ERRORS = NO
@@ -31,14 +32,6 @@ class Mas < Formula
     ENV["XCODE_XCCONFIG_FILE"] = xcconfig
 
     system "carthage", "bootstrap", "--platform", "macOS"
-
-    xcodebuild "install",
-                "-project", "mas-cli.xcodeproj",
-                "-scheme", "mas-cli Release",
-                "-configuration", "Release",
-                "OBJROOT=build",
-                "SYMROOT=build"
-
     system "script/install", prefix
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"


### PR DESCRIPTION
New formula for mas [1.4.4](https://github.com/mas-cli/mas/releases/tag/v1.4.4) published to core tap in Homebrew/homebrew-core#35276