### PR TITLE
🍼 Add bottles for 1.6.0

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -2,17 +2,17 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      :tag      => "v1.5.0",
-      :revision => "ccaaa74c9593d04dc41fcff40af196fdad49f517"
+      :tag      => "v1.6.0",
+      :revision => "af1e9d4cb404164fbe4e8db73159e1e15c0b3184"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do
     root_url "https://dl.bintray.com/phatblat/mas-bottles"
     cellar :any
-    sha256 "e12ef9a1351214e59011326b913d03800fa5c5e07b50681051e50dc98fa2d05a" => :mojave
-    sha256 "e12ef9a1351214e59011326b913d03800fa5c5e07b50681051e50dc98fa2d05a" => :high_sierra
-    sha256 "e12ef9a1351214e59011326b913d03800fa5c5e07b50681051e50dc98fa2d05a" => :sierra
-    sha256 "e12ef9a1351214e59011326b913d03800fa5c5e07b50681051e50dc98fa2d05a" => :el_capitan
+    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :mojave
+    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :high_sierra
+    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :sierra
+    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :el_capitan
   end
 
   depends_on "carthage" => :build
@@ -38,5 +38,6 @@ class Mas < Formula
 
   test do
     assert_equal version.to_s, shell_output("#{bin}/mas version").chomp
+    assert_include shell_output("#{bin}/mas info 497799835"), "Xcode"
   end
 end


### PR DESCRIPTION
New formula for mas [1.6.0](https://github.com/mas-cli/mas/releases/tag/v1.6.0) published to core tap in Homebrew/homebrew-core#35948