### PR TITLE
🍼 Update bottles for 1.6.1

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -2,8 +2,8 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      :tag      => "v1.6.0",
-      :revision => "af1e9d4cb404164fbe4e8db73159e1e15c0b3184"
+      :tag      => "v1.6.1",
+      :revision => "153c40868b7e1a4f5c587f998209f60740ecc26c"
   head "https://github.com/mas-cli/mas.git"
 
   bottle do

--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -9,10 +9,10 @@ class Mas < Formula
   bottle do
     root_url "https://dl.bintray.com/phatblat/mas-bottles"
     cellar :any
-    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :mojave
-    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :high_sierra
-    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :sierra
-    sha256 "8abb404d968f2b6201b2afdb199eb3154403c242821dc9bb6fb71597c5b85738" => :el_capitan
+    sha256 "9388aef5d3035366e4d032984979600907dd838c325076aafe288de77c841784" => :mojave
+    sha256 "9388aef5d3035366e4d032984979600907dd838c325076aafe288de77c841784" => :high_sierra
+    sha256 "9388aef5d3035366e4d032984979600907dd838c325076aafe288de77c841784" => :sierra
+    sha256 "9388aef5d3035366e4d032984979600907dd838c325076aafe288de77c841784" => :el_capitan
   end
 
   depends_on "carthage" => :build


### PR DESCRIPTION
Core formula updated in Homebrew/homebrew-core#36166

Uploaded bottles to bintray for [version 1.6.1](https://bintray.com/phatblat/mas-bottles/mas/1.6.1?sort=&order=).