### PR TITLE
🛠 Remove Carthage dependency, xcconfig overrides

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -22,7 +22,7 @@ class Mas < Formula
   if Hardware::CPU.arm?
     depends_on xcode: ["12.2", :build]
   else
-    depends_on xcode: ["11.4", :build]
+    depends_on xcode: ["12.0", :build]
   end
 
   def install

--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -18,7 +18,6 @@ class Mas < Formula
     sha256 cellar: :any, el_capitan:    "d54d864976f78665d5175fd9e69ab81b3911fa28fd6ae627b61a18d55d68191a"
   end
 
-  depends_on "carthage" => :build
   depends_on :macos
   if Hardware::CPU.arm?
     depends_on xcode: ["12.2", :build]
@@ -27,18 +26,6 @@ class Mas < Formula
   end
 
   def install
-    # Working around build issues in dependencies
-    # - Prevent warnings from causing build failures
-    # - Prevent linker errors by telling all lib builds to use max size install names
-    xcconfig = buildpath/"Overrides.xcconfig"
-    xcconfig.write <<~EOS
-      GCC_TREAT_WARNINGS_AS_ERRORS = NO
-      OTHER_LDFLAGS = -headerpad_max_install_names
-    EOS
-    ENV["XCODE_XCCONFIG_FILE"] = xcconfig
-
-    # Only build necessary dependencies
-    system "carthage", "bootstrap", "--platform", "macOS", "Commandant"
     system "script/install", prefix
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"


### PR DESCRIPTION
Changes corresponding to https://github.com/mas-cli/mas/pull/350.

We really only need Swift 5.3 now and not all of Xcode, but there's no `depends_on swift:` [yet](https://github.com/Homebrew/homebrew-core/pull/76206#issuecomment-828879671).

Fixes #5.