### PR TITLE
🍺 Add support for macOS 12 Monterey

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -5,7 +5,7 @@ class Mas < Formula
       tag:      "v1.8.3",
       revision: "aeeb1c508e98d657769ef4e368a113be7822d92e"
   license "MIT"
-  head "https://github.com/mas-cli/mas.git"
+  head "https://github.com/mas-cli/mas.git", branch: "main"
 
   bottle do
     root_url "https://github.com/mas-cli/mas/releases/download/v1.8.3"


### PR DESCRIPTION
To be clear, https://github.com/mas-cli/mas/issues/417 is still an issue preventing any significant utility of `mas` on macOS 12.

This change just adds Monterey to the list of (duplicate) bottles.