### PR TITLE
Don't call `script/install` from formula so it can be removed

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -33,7 +33,7 @@ class Mas < Formula
 
   def install
     system "script/build"
-    system "script/install", prefix
+    bin.install ".build/release/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
     fish_completion.install "contrib/completion/mas.fish"


### PR DESCRIPTION
Don't call `script/install` from formula so it can be removed.

Resolve #58