### PR TITLE
Pass `--disable-sandbox` as an argument to `script/build`.

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -21,7 +21,7 @@ class Mas < Formula
   depends_on :macos
 
   def install
-    system "script/build"
+    system "script/build", "--disable-sandbox"
     bin.install ".build/release/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"


### PR DESCRIPTION
Use swift build sandbox for non-Homebrew builds.

Pass `--disable-sandbox` as an argument to `script/build` in the Homebrew build.

That flag will not cause a problem with the old `script/build`, so it's safe to add before the new `script/build` is used.

Resolve #62