### PR TITLE
Update formula for 1.9.0.

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -21,7 +21,8 @@ class Mas < Formula
   depends_on :macos
 
   def install
-    system "script/build", "--disable-sandbox"
+    ENV["MAS_DIRTY_INDICATOR"] = ""
+    system "script/build", "mas-cli/tap/mas", "--disable-sandbox"
     bin.install ".build/release/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"


### PR DESCRIPTION
Add `mas-cli/tap/mas` argument to `script/build` to specify the install method.

Set `MAS_DIRTY_INDICATOR=0` to fix a version check while building bottles.

Resolve #93