### PR TITLE
Rename ventura bottles to catalina because mas can now run on only macOS 10.15+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
             sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
           else
             built=ventura
-            deploy=high_sierra
+            deploy=catalina
           fi
 
           brew test-bot --only-formulae


### PR DESCRIPTION
Rename ventura bottles to catalina because mas can now run on only macOS 10.15+.

Resolve #97